### PR TITLE
add codecov integration for frontend ci

### DIFF
--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -3,12 +3,8 @@ name: Frontend Tests
 on:
   push:
     branches: [ master ]
-    paths:
-      - 'frontend/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - 'frontend/**'
 
 jobs:
   build:
@@ -36,3 +32,9 @@ jobs:
         with:
           name: deploy_coverage
           path: frontend/coverage
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/coverage/cashbox-frontend/lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
since the code coverage is measured now it is important to update the
coverage every time so that the codecov tool can create a diff to the
master branch. Therefore, the directory filter is removed.